### PR TITLE
Ajout injection LocalStorageRepository

### DIFF
--- a/src/app/repository/LocalStorageRepository.ts
+++ b/src/app/repository/LocalStorageRepository.ts
@@ -13,7 +13,7 @@ export class LocalStorageRepository {
 
     constructor() {
         this.key = 'CADMIUM_TASKS';
-        window.localStorage.getItem(this.key) === undefined
+        window.localStorage.getItem(this.key) === null
             ? window.localStorage.setItem(
                   this.key,
                   JSON.stringify({

--- a/src/app/repository/local-storage-repository.service.spec.ts
+++ b/src/app/repository/local-storage-repository.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LocalStorageRepositoryService } from './local-storage-repository.service';
+
+describe('LocalStorageRepositoryService', () => {
+    let service: LocalStorageRepositoryService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        service = TestBed.inject(LocalStorageRepositoryService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+});

--- a/src/app/repository/local-storage-repository.service.ts
+++ b/src/app/repository/local-storage-repository.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { LocalStorageRepository } from './LocalStorageRepository';
+
+@Injectable({
+    providedIn: 'root',
+})
+/**
+ * Service used to inject LocalStorageRepository
+ */
+export class LocalStorageRepositoryService {
+    private localStorageRepository: LocalStorageRepository;
+
+    constructor() {
+        this.localStorageRepository = new LocalStorageRepository();
+    }
+
+    public getLocalStorageRepository() {
+        return this.localStorageRepository;
+    }
+}


### PR DESCRIPTION
Ajout d'un service LocalStorageRepositoryService pouvant être injecté n'importe où dans le projet ayant une instance de LocalStorageRepository en attribut.

Cet instance est retournée par ``LocalStorageRepositoryService.getLocalStorageRepository()``.

Correction d'une erreur empêchant la création de l'objet servant au stockage.